### PR TITLE
docs: add repo card (CLAUDE.md) [MIX-177]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,26 +5,26 @@
 ## What it is
 A small CommonJS utility for reading metadata about the EC2 instance it runs on: arbitrary instance-metadata fields and the instance-identity document (via the link-local `169.254.169.254` endpoint), plus EC2 resource tags (via the AWS SDK). Single-file npm module, consumed by services that want to tag logs/errors with instance identity.
 
-## serves          # CROSS-CUTTING (shared infra library) — owns no product domain
+## serves
 role: Shared library for reading the current EC2 instance's metadata, identity document, and tags at runtime.
 referenced-by: [services that annotate errors/logs/observability context with EC2 instance identity]
 
-## Code map        # entry points only — paths/globs, not explanations
+## Code map
 - public API -> index.js  (exports `fetch`, `fetchInstanceIdentity`, `fetchTag`)
 - tests      -> test/index.test.js
 
-## Conventions     # the few non-obvious rules an agent would get wrong; link the rest
+## Conventions
 - CommonJS (`require` / `module.exports`); `main` is `index.js`, the whole module is that one file.
 - `fetch(field)` and `fetchInstanceIdentity()` hit the link-local metadata endpoint `http://169.254.169.254`; `fetchTag(tag)` resolves the instance id/region then calls EC2 `DescribeTags` via `@aws-sdk/client-ec2`.
 - Lint/format via `eslint-config-mixmax` + Prettier; Node pinned to 18.13.0 (`.nvmrc`).
 
-## Gotchas         # high-signal "easy to get wrong"
+## Gotchas
 - Only works on a real EC2 instance — the `169.254.169.254` endpoint is unreachable elsewhere; tests mock it with `nock`.
 - `fetchTag` needs the instance role to allow `ec2:DescribeTags`; it returns `null` when the tag is absent.
 
 ## Run / test
 - `npm test` (jest) · `npm run lint` (eslint) · `npm run ci` (lint + test)
-- Publish: `npx semantic-release` (runs from CI).
+- Publish (manual, not CI): `GH_TOKEN=xxx npx semantic-release --no-ci`
 
 ## Load the matching domain card
 - This repo is a cross-cutting infra library — it owns no product domain, so there is no domain card to load. When working here, load the card of the consuming service if the change is driven by that service's needs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,30 @@
+# aws-instance-metadata — repo card
+
+> A map, not a manual. Keep it ~1 screen; point to detail, don't inline it.
+
+## What it is
+A small CommonJS utility for reading metadata about the EC2 instance it runs on: arbitrary instance-metadata fields and the instance-identity document (via the link-local `169.254.169.254` endpoint), plus EC2 resource tags (via the AWS SDK). Single-file npm module, consumed by services that want to tag logs/errors with instance identity.
+
+## serves          # CROSS-CUTTING (shared infra library) — owns no product domain
+role: Shared library for reading the current EC2 instance's metadata, identity document, and tags at runtime.
+referenced-by: [services that annotate errors/logs/observability context with EC2 instance identity]
+
+## Code map        # entry points only — paths/globs, not explanations
+- public API -> index.js  (exports `fetch`, `fetchInstanceIdentity`, `fetchTag`)
+- tests      -> test/index.test.js
+
+## Conventions     # the few non-obvious rules an agent would get wrong; link the rest
+- CommonJS (`require` / `module.exports`); `main` is `index.js`, the whole module is that one file.
+- `fetch(field)` and `fetchInstanceIdentity()` hit the link-local metadata endpoint `http://169.254.169.254`; `fetchTag(tag)` resolves the instance id/region then calls EC2 `DescribeTags` via `@aws-sdk/client-ec2`.
+- Lint/format via `eslint-config-mixmax` + Prettier; Node pinned to 18.13.0 (`.nvmrc`).
+
+## Gotchas         # high-signal "easy to get wrong"
+- Only works on a real EC2 instance — the `169.254.169.254` endpoint is unreachable elsewhere; tests mock it with `nock`.
+- `fetchTag` needs the instance role to allow `ec2:DescribeTags`; it returns `null` when the tag is absent.
+
+## Run / test
+- `npm test` (jest) · `npm run lint` (eslint) · `npm run ci` (lint + test)
+- Publish: `npx semantic-release` (runs from CI).
+
+## Load the matching domain card
+- This repo is a cross-cutting infra library — it owns no product domain, so there is no domain card to load. When working here, load the card of the consuming service if the change is driven by that service's needs.


### PR DESCRIPTION
## What

Adds a `CLAUDE.md` **repo card** for `aws-instance-metadata`, following the Milestone 0 repo-card standard (defined in `Company-Context`, MIX-170).

`aws-instance-metadata` is a small cross-cutting infra library (reads EC2 instance metadata / identity / tags), so the card uses a `serves:` block rather than `domain:`. Kept thin per the tier-3 guidance.

The card covers the base blocks: what-it-is · `serves:` · code map · conventions · gotchas · run/test · the load-domain-card directive.

## Why

Part of [MIX-177](https://linear.app/mixmax/issue/MIX-177) (M0-2e — Tier 3 repo cards: infra / Terraform / tooling). Repo cards give an AI session the map of a repo it would otherwise lack.

## Test plan

- [x] Card follows the base template and `serves:` schema keys exactly.
- [x] Values verified against the repo's `index.js` exports, `package.json` scripts, and `.nvmrc`.
- N/A — docs-only change, no code affected.